### PR TITLE
Fix PlatformIO async networking dependencies

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,6 @@ board_build.partitions = huge_app.csv
 lib_deps =
     lovyan03/LovyanGFX
     tzapu/WiFiManager
-    mathieucarbou/ESP Async WebServer
-    mathieucarbou/AsyncTCP
+    ESP32Async/ESPAsyncWebServer
+    ESP32Async/AsyncTCP
     bblanchon/ArduinoJson


### PR DESCRIPTION
Updates the `PlatformIO async` networking dependencies to use the current `ESP32Async` packages.
Fixes linker errors caused by `PlatformIO` resolving multiple `AsyncTCP` implementations.

The `mathieucarbou` repositories were moved to the `ESP32Async` organization, and the old repos were archived.