### PR TITLE
Ignore generated compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ avr-toolchain-*.zip
 /app/build/
 /arduino-core/build/
 
+compile_commands.json
 manifest.mf
 nbbuild.xml
 nbproject


### PR DESCRIPTION
Adds `compile_commands.json` to `.gitignore`.

This file is generated locally during development and does not need to be tracked in the repository.